### PR TITLE
Make it work for 3.36 where get_anchor_point was removed

### DIFF
--- a/dynamic-panel-transparency@rockon999.github.io/intellifade.js
+++ b/dynamic-panel-transparency@rockon999.github.io/intellifade.js
@@ -112,16 +112,24 @@ function _updateBounds() {
 
     this.scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
 
-    let anchor_y = -Main.layoutManager.panelBox.get_anchor_point()[1];
     let pivot_y = -Main.layoutManager.panelBox.get_pivot_point()[1];
+    if (typeof Main.layoutManager.panelBox.get_anchor_point === 'function') {
+        let anchor_y = -Main.layoutManager.panelBox.get_anchor_point()[1];
 
-    // Adjust for bottom panel.
-    if (anchor_y > 0) {
-        this.panel_bounds.y = anchor_y;
-        this.panel_bounds.is_top = false;
-    } else if (pivot_y > 0) {
-        this.panel_bounds.y = pivot_y;
-        this.panel_bounds.is_top = false;
+        // Adjust for bottom panel.
+        if (anchor_y > 0) {
+            this.panel_bounds.y = anchor_y;
+            this.panel_bounds.is_top = false;
+        } else if (pivot_y > 0) {
+            this.panel_bounds.y = pivot_y;
+            this.panel_bounds.is_top = false;
+        }
+    } else {
+        // Adjust for bottom panel.
+        if (pivot_y > 0) {
+            this.panel_bounds.y = pivot_y;
+            this.panel_bounds.is_top = false;
+        }
     }
 }
 


### PR DESCRIPTION
It should also work as before for older versions.

Fixes #111 